### PR TITLE
Issue #1 - Module Added Event

### DIFF
--- a/classes/event/course_module_added.php
+++ b/classes/event/course_module_added.php
@@ -1,0 +1,49 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * The mod_syllabus instance list viewed event.
+ *
+ * @package    mod_syllabus
+ * @copyright  2021 Marty Gilbert <martygilbert@gmail>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_syllabus\event;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * The mod_syllabus instance added event class
+ *
+ * @package    mod_syllabus
+ * @since      Moodle 3.9
+ * @copyright  2021 Marty Gilbert <martygilbert@gmail>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class course_module_added extends \core\event\base {
+    // No need for any code here as everything is handled by the parent class.
+    /**
+     * Init method.
+     *
+     * @return void
+     */
+    protected function init() {
+        $this->data['crud'] = 'u';
+        $this->data['edulevel'] = self::LEVEL_TEACHING;
+        $this->data['objecttable'] = 'syllabus';
+    }
+}

--- a/lib.php
+++ b/lib.php
@@ -108,6 +108,10 @@ function syllabus_add_instance($data, $mform) {
     $completiontimeexpected = !empty($data->completionexpected) ? $data->completionexpected : null;
     \core_completion\api::update_completion_date_event($cmid, 'syllabus', $data->id, $completiontimeexpected);
 
+    $context = context_module::instance($data->coursemodule);
+	$event = \mod_syllabus\event\course_module_added::create(array('context' => $context, 'objectid' => $data->coursemodule));
+	$event->trigger();
+
     return $data->id;
 }
 
@@ -132,14 +136,9 @@ function syllabus_update_instance($data, $mform) {
     $completiontimeexpected = !empty($data->completionexpected) ? $data->completionexpected : null;
     \core_completion\api::update_completion_date_event($data->coursemodule, 'syllabus', $data->id, $completiontimeexpected);
 
-	// MJG - the syllabus has been updated; trigger the update event.
-	error_log("Just triggered the event - anything happen?");
     $context = context_module::instance($data->coursemodule);
 	$event = \mod_syllabus\event\course_module_updated::create(array('context' => $context, 'objectid' => $data->coursemodule));
 	$event->trigger();
-	//error_log(print_r($data, true));
-	//error_log("MFORM");
-	//error_log(print_r($mform, true));
 
     return true;
 }


### PR DESCRIPTION
This adds an event that is triggered when a syllabus is added.
This will be observed by Syllabus Viewer, so a syllabus can be
added to the viewer when a new one is created.